### PR TITLE
Fix documentation and add/remove/delete actions

### DIFF
--- a/README.md
+++ b/README.md
@@ -96,7 +96,109 @@ all_cmds = shell.all_osp_commands
 ```
 ### Executing Commands
 Once you have an idea of what commands you want to execute you have a few different ways of 
-executing them. Below we will walk through the available options
+executing them. Before we dive into those, let's talk a little bit about generating the options
+and their arguments. 
+
+### Options
+
+The options and argument values for the command actions are always defined as dictionaries. Let's
+touch on a couple examples
+
+#### Example 1
+
+Any time an option takes an argument
+```python
+
+# This
+command create --option arg <res_name>
+
+
+# Can be defined like
+{'option': 'arg', 'name': 'res_name'}
+```
+
+#### Example 2
+Any time an option takes an argument and can be specified multiple times 
+```python
+
+# This
+command create --option arg1 --option arg2 <res_name>
+
+# Can be defined like
+{'option': ['arg1', 'arg2'], 'name': 'res_name'}
+```
+
+#### Example 3
+Any time an option takes an argument with the value in k=v 
+```python
+
+# This
+command create --option arg1=val1
+
+# Can be defined like
+{'option': [{'arg1': 'val1'}], 'name': 'res_name'} 
+```
+
+#### Example 4
+Any time an option takes an argument with the value in k=v and can be specified multiple times. 
+```python
+
+# This
+command create --option arg1=val1 --option arg2=val2 <res_name>
+
+# Can be defined like
+{'option': [{'arg1': 'val1'}, {'arg2': 'val2'}], 'name': 'res_name'}
+```
+
+#### Example 5
+Any time an option takes an argument but the value can be a comma separated list of k=v 
+```python
+
+# This
+command create --option arg1=val1,arg2=val2,arg3=val3 <res_name>
+
+# Can be defined like
+{'option': [{'arg1': 'val1', 'arg2': 'val2', 'arg3': 'val3'}], 'name': 'res_name'}
+```
+
+#### Example 6
+Any time an option takes no argument and actions like a boolean flag 
+```python
+
+# This
+command create --option <res_name>
+
+# Can be defined like
+{'option': True, 'name': 'res_name'}
+```
+
+#### Example 7
+In the case of *add* command actions, which not only require the name or id of the resource
+it needs the name or id of the target resource you want to add
+```python
+
+# This
+command add --option arg1 <res_name> <tgt_res>
+
+# Can be defined like
+{'option': 'arg1', 'name': 'res_name', 'tgt_name': 'tgt_res'}
+```
+**Note** rather than `name` you could supply `id` and rather than `tgt_name` you can supply `tgt_id` 
+
+#### Example 7
+In the case of *delete* command actions, you can specify multiple resources
+```python
+
+# This
+command delete <res_name_1> <res_name_2>
+
+# Can be defined like
+{'name': ['res_name_1', 'res_name_2']}
+```
+
+
+For a full list of commands and options refer to the
+[openstackclient](https://docs.openstack.org/python-openstackclient/latest/cli/command-list.html) documentation. 
 
 #### High Level APIs
 The first and recommended way is to use the high level APIs the shell provides 

--- a/ospclientsdk/helpers/decorators.py
+++ b/ospclientsdk/helpers/decorators.py
@@ -135,6 +135,10 @@ class Command(object):
         cmd_str = ""
         if isinstance(options, dict):
             asset = options.pop('name') if options.get('name', None) else options.pop('id', None)
+
+            # This most likely means it's an add command so we need to append this as the last argument
+            target = options.pop('tgt_name') if options.get('tgt_name', None) else options.pop('tgt_id', None)
+
             for key, val in options.items():
                 if isinstance(val, list):
                     for item in val:
@@ -160,7 +164,11 @@ class Command(object):
                     continue
                 cmd_str += "--%s %s " % (key.replace('_', '-'), val)
             if asset:
+                if isinstance(asset, list):
+                    asset = " ".join(asset)
                 cmd_str += asset
+            if target:
+                cmd_str += " %s" % target
         return cmd_str
 
     def exec_local_cmd(self, cmd):


### PR DESCRIPTION
 * Fixes issue #7

 * Updated the README.md to include better examples on how to
   populate the dictionary to pass to the high level apis

 * Fixed the the issue where it couldn't run the add/remove action
   since there was no dictionary key to identify it was a target
   resource and not an option.

 * Fixed the ability to be able to delete a list of openstack
   resources