### PR TITLE
Add remote proxy/bastion host support

### DIFF
--- a/ospclientsdk/__init__.py
+++ b/ospclientsdk/__init__.py
@@ -7,6 +7,7 @@
 """
 
 from .shell import ClientShell
+from .helpers.context import *
 
 __version__ = '0.3.0'
 __author__ = 'Danny Baez'

--- a/ospclientsdk/helpers/__init__.py
+++ b/ospclientsdk/helpers/__init__.py
@@ -8,3 +8,4 @@
 """
 
 from .decorators import Command
+from .context import *

--- a/ospclientsdk/helpers/context.py
+++ b/ospclientsdk/helpers/context.py
@@ -1,0 +1,132 @@
+import os
+from threading import local
+from logging import getLogger
+
+LOG = getLogger(__name__)
+
+
+def cur_context():
+    """
+    This is used by the Command object functions
+    to retrieve the SshContext object from the local
+    context stack.
+    """
+    if context.stack:
+        return context.stack[-1]
+
+
+class SshContext(object):
+    """
+    SshContext is a context object
+    that gets initialized by the remote_shell
+    function and stores all the SSH data to
+    be sent to Command decorator.
+    """
+    def __init__(self,
+                 hostname=None,
+                 username='root',
+                 port=22,
+                 password=None,
+                 connect_timeout=600,
+                 key_file=None,
+                 ssh_opts=(),
+                 client_path=None):
+
+        self.client_path = client_path
+        self.hostname = hostname
+        self.username = username
+        self.port = port
+        self.password = password
+        self.connect_timeout = connect_timeout
+        self.key_file = key_file
+        self.ssh_opts = ssh_opts
+
+    def __enter__(self):
+        """
+        When in context it adds itself
+        to the local context stack.
+
+        :return: SshContext Object
+        """
+        context.stack.append(self)
+        return self
+
+    def __exit__(self, exc_type, exc_val, exc_tb):
+        """
+        Once the context is exited, it removes itself
+        from the local context stack.
+
+        :param exc_type:
+        :param exc_val:
+        :param exc_tb:
+        :return:
+        """
+        context.stack.pop()
+
+    def get_os_vars(self):
+        """
+        Retrieves the local OS auth environmental
+        variables set locally so that they can be
+        set remotely
+
+        :return: dict
+        """
+        vars_dict = {k: v for k, v in os.environ.items() if k.find('OS_') != -1}
+        return vars_dict
+
+
+def remote_shell(hostname=None,
+                 port=22,
+                 username='root',
+                 password=None,
+                 connect_timeout=600,
+                 key_file=None,
+                 ssh_opts=[],
+                 client_path=None):
+    """
+    Used by 'with' to SSH to a remote host and run commands
+    remotely.
+
+    :param hostname: the shortname,FQDN, or IP of the host to connect to
+    :param port: the port to use, will default to 22
+    :param username: the username to login with, will default to 'root'
+    :param password: the password to login with. Not required if using key_file
+    :param connect_timeout: the connection timeout, defaults to 5 minutes
+    :param key_file: the ssh key file (-i ) that should be used for passwordless ssh. Not required if using password
+    :param ssh_opts: ssh options to append to the connection
+    :param client_path: an alternative path that should be used to get to the 'openstack' command when not in $PATH
+    :return: SshContext object
+    """
+
+    if key_file:
+        key_file = os.path.abspath(key_file)
+
+    _ssh_opts = ['-oPasswordAuthentication=no',
+                 '-oStrictHostKeyChecking=no']
+
+    if ssh_opts:
+        _ssh_opts.extend(ssh_opts)
+
+    c = SshContext(hostname=hostname,
+                   port=port,
+                   username=username,
+                   password=password,
+                   connect_timeout=connect_timeout,
+                   key_file=key_file,
+                   ssh_opts=tuple(set(_ssh_opts).union(ssh_opts)) if ssh_opts else tuple(_ssh_opts),
+                   client_path=client_path
+                   )
+
+    return c
+
+
+class LocalContext(local):
+
+    def __init__(self):
+
+        self.stack = []
+
+
+# All threads will have a context which is
+# managed by a stack of Context objects.
+context = LocalContext()

--- a/ospclientsdk/shell.py
+++ b/ospclientsdk/shell.py
@@ -11,8 +11,6 @@ __all__ = ["ClientShell"]
 
 import yaml
 import os
-import json
-import logging
 from .helpers import *
 from .exceptions import OspShellError
 from .constants import LOG_FORMAT, LOG_LEVELS, DEBUG_LOG_FORMAT

--- a/setup.py
+++ b/setup.py
@@ -8,19 +8,20 @@ VERSION_RE = re.compile(r'''__version__ = ['"]([a-zA-Z0-9.]+)['"]''')
 
 
 def get_version():
+    """Return the version number"""
     init = open(os.path.join(ROOT, 'ospclientsdk', '__init__.py')).read()
     return VERSION_RE.search(init).group(1)
 
+
+def get_long_description():
+    """Returns README.md content."""
+    return open("README.md", "r").read()
 
 setup(
     name='ospclientsdk',
     version=get_version(),
     description="An SDK like wrapper around the openstackclient.",
-    long_description="""
-    ospclientsdk provides an sdk like wrapper API around the openstackclient.
-    It removes the need to write boiler plate code around subprocess to execute
-    openstack cli commands.
-    """,
+    long_description=get_long_description(),
     author="Danny Baez",
     url="https://github.com/Dannyb48/ospclientsdk",
     author_email='danny.baez.jr@gmail.com',
@@ -31,6 +32,7 @@ setup(
         'Intended Audience :: Developers',
         'Topic :: Software Development :: Quality Assurance',
         'Topic :: Software Development :: Libraries :: Python Modules',
+        'Environment :: OpenStack',
         'Natural Language :: English',
         'License :: OSI Approved :: GNU General Public License v3 (GPLv3)',
         'Programming Language :: Python',
@@ -41,4 +43,7 @@ setup(
         'openstackclient',
         'PyYaml'
     ],
+    extras_require={
+        'remote_shell': ['plumbum']
+    }
 )

--- a/test-requirements.txt
+++ b/test-requirements.txt
@@ -7,3 +7,4 @@ pytest>=3.7.3
 pytest-cov
 tox>=2.7.0
 openstackclient
+plumbum


### PR DESCRIPTION
 * Should address issue #6
 * Added a context package so that remote bastion host can be done
   using a context manager
 * Added plumbum as an extras package
 * Added documentation in the readme showing examples of running
   with the context manager
 * Added a long description function to read and load the readme
 * Added a couple tests around the new context logic