### PR TITLE
Add support for tripleo client #11

### DIFF
--- a/README.md
+++ b/README.md
@@ -114,7 +114,7 @@ command create --option arg <res_name>
 
 
 # Can be defined like
-{'option': 'arg', 'name': 'res_name'}
+{'option': 'arg', 'res': 'res_name'}
 ```
 
 #### Example 2
@@ -125,7 +125,7 @@ Any time an option takes an argument and can be specified multiple times
 command create --option arg1 --option arg2 <res_name>
 
 # Can be defined like
-{'option': ['arg1', 'arg2'], 'name': 'res_name'}
+{'option': ['arg1', 'arg2'], 'res': 'res_name'}
 ```
 
 #### Example 3
@@ -136,7 +136,7 @@ Any time an option takes an argument with the value in k=v
 command create --option arg1=val1
 
 # Can be defined like
-{'option': [{'arg1': 'val1'}], 'name': 'res_name'} 
+{'option': [{'arg1': 'val1'}], 'res': 'res_name'} 
 ```
 
 #### Example 4
@@ -147,7 +147,7 @@ Any time an option takes an argument with the value in k=v and can be specified 
 command create --option arg1=val1 --option arg2=val2 <res_name>
 
 # Can be defined like
-{'option': [{'arg1': 'val1'}, {'arg2': 'val2'}], 'name': 'res_name'}
+{'option': [{'arg1': 'val1'}, {'arg2': 'val2'}], 'res': 'res_name'}
 ```
 
 #### Example 5
@@ -158,7 +158,7 @@ Any time an option takes an argument but the value can be a comma separated list
 command create --option arg1=val1,arg2=val2,arg3=val3 <res_name>
 
 # Can be defined like
-{'option': [{'arg1': 'val1', 'arg2': 'val2', 'arg3': 'val3'}], 'name': 'res_name'}
+{'option': [{'arg1': 'val1', 'arg2': 'val2', 'arg3': 'val3'}], 'res': 'res_name'}
 ```
 
 #### Example 6
@@ -169,7 +169,7 @@ Any time an option takes no argument and actions like a boolean flag
 command create --option <res_name>
 
 # Can be defined like
-{'option': True, 'name': 'res_name'}
+{'option': True, 'res': 'res_name'}
 ```
 
 #### Example 7
@@ -181,7 +181,7 @@ it needs the name or id of the target resource you want to add
 command add --option arg1 <res_name> <tgt_res>
 
 # Can be defined like
-{'option': 'arg1', 'name': 'res_name', 'tgt_name': 'tgt_res'}
+{'option': 'arg1', 'res': 'res_name', 'tgt_res': 'tgt_res'}
 ```
 **Note** rather than `name` you could supply `id` and rather than `tgt_name` you can supply `tgt_id` 
 
@@ -193,7 +193,7 @@ In the case of *delete* command actions, you can specify multiple resources
 command delete <res_name_1> <res_name_2>
 
 # Can be defined like
-{'name': ['res_name_1', 'res_name_2']}
+{'res': ['res_name_1', 'res_name_2']}
 ```
 
 
@@ -338,7 +338,7 @@ shell = ClientShell(cloud_file='clouds.yaml', cloud='test')
 
 # Build a dictionary of the required arguements/options and their parameters.
 # Each key is command option and the value is the parameter.
-server_params = dict(name="ccit_test_client",
+server_params = dict(res="ccit_test_client",
                      image="rhel-7.5-server-x86_64-released",
                      flavor="m1.small",
                      key_name="db2-test",

--- a/ospclientsdk/helpers/decorators.py
+++ b/ospclientsdk/helpers/decorators.py
@@ -63,7 +63,6 @@ class Command(object):
         # mixin classes does not have a defined function yet that maps to a particular
         # command on the CLI.
         elif len(args) == 3:
-            LOG.info(args)
             return self.run_cmd(args[1], args[2], context=cur_context())
 
     def __get__(self, instance, owner):
@@ -88,7 +87,6 @@ class Command(object):
             opts += ' -f json'
         cmd_str = self.default_os_command_template.safe_substitute(command=cmd, options=opts)
 
-        LOG.info(cmd_str)
         return self.run_cmd_raw(cmd_str, context)
 
     def run_cmd_raw(self, command, context=None):
@@ -140,10 +138,10 @@ class Command(object):
         """
         cmd_str = ""
         if isinstance(options, dict):
-            asset = options.pop('name') if options.get('name', None) else options.pop('id', None)
+            asset = options.pop('res', None)
 
             # This most likely means it's an add command so we need to append this as the last argument
-            target = options.pop('tgt_name') if options.get('tgt_name', None) else options.pop('tgt_id', None)
+            target = options.pop('tgt_res', None)
 
             for key, val in options.items():
                 if isinstance(val, list):

--- a/setup.py
+++ b/setup.py
@@ -45,6 +45,7 @@ setup(
         'PyYaml'
     ],
     extras_require={
-        'remote_shell': ['plumbum']
+        'remote_shell': ['plumbum'],
+        'tripleo': ['python-tripleoclient']
     }
 )

--- a/test-requirements.txt
+++ b/test-requirements.txt
@@ -6,5 +6,3 @@ pytest>=3.7.3
 #locking pytest-cov due to a regression with 2.8.0
 pytest-cov
 tox>=2.7.0
-openstackclient
-plumbum

--- a/tests/test_helpers.py
+++ b/tests/test_helpers.py
@@ -42,8 +42,12 @@ class TestCommandDecorator(object):
     @staticmethod
     @mock.patch.object(Command, 'exec_local_cmd', exec_local_cmd)
     def test_command_call_normalize_options():
+        final_options="""
+        --list-1 k-1=v1,k-2=v2 --list-1 k-3=v3,k-4=v4 --list-2 k-5=v5 --list-3 net1 --list-3 net2 --is-true --max 2 --p-dir /tmp --p-file /tmp/key test tgt
+        """
         options = dict(
-                    name='test',
+                    res='test',
+                    tgt_res='tgt',
                     list_1=[
                         dict(k_1='v1',
                              k_2='v2'
@@ -65,7 +69,8 @@ class TestCommandDecorator(object):
             print("%s %s" % (func, option))
 
         cmd = Command(func=mock_run)
-        cmd('server_show', options)
+        noption = getattr(cmd, '_normalize_options')(options)
+        assert noption.find(final_options)
 
     @staticmethod
     @mock.patch.object(Command, 'exec_local_cmd', exec_local_cmd)

--- a/tests/test_shell.py
+++ b/tests/test_shell.py
@@ -17,17 +17,7 @@ def flat_dict():
                 project_name='test')
 
 
-@pytest.fixture(scope='class')
-def server_create_options():
-    return dict(image='rhel-7.5-server-x86_64',
-                flavor='m1.small',
-                network=['provider_net', 'private_net'],
-                max=2,
-                key_name='test-key')
-
-
 class TestShell(object):
-
 
     @staticmethod
     def test_shell_creds_dict(clouds_dict):


### PR DESCRIPTION
 * Added the python-tripleoclient to setup.py
 * Had to change the name and tgt_name to res and tgt_res since
   tripleo has --name option
 * Updated the README.md with the res options
 * removed some unneccesary logging statements
 * Updated test_helpers normalize_options_test